### PR TITLE
Emucon default path simplified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ bdos_src = bdosmain.c console.c fsbuf.c fsdir.c fsdrive.c fsfat.c fsglob.c \
 #
 
 util_src = cookie.c doprintf.c intmath.c langs.c memmove.S memset.S miscasm.S \
-           nls.c nlsasm.S setjmp.S string.c
+           nls.c nlsasm.S setjmp.S string.c shellutl.c
 
 # The functions in the following modules are used by the AES and EmuDesk
 ifeq ($(WITH_AES),1)

--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -758,7 +758,7 @@ void run_accs_and_desktop(void)
 static void new_resolution(WORD rez, WORD videlmode)
 {
     Setscreen(-1L, -1L, rez, videlmode);        /* change resolution */
-    Setscreen(-1L, -1L, 0xc000|rez, videlmode); /* init palette regs */
+    initialise_palette_registers(rez, videlmode);
 }
 #endif
 

--- a/aes/gemshlib.c
+++ b/aes/gemshlib.c
@@ -539,6 +539,9 @@ static void sh_chdef(SHELL *psh)
         set_drvdir(sh_apdir);
         break;
     case CONSOLE_APP:
+#if WITH_CLI
+        set_drvdir(psh->sh_cdir);   /* set by EmuDesk via shel_wdef() */
+#endif
         break;
     case AUTORUN_APP:
     case DESKTOP_APP:

--- a/aes/gemshlib.c
+++ b/aes/gemshlib.c
@@ -609,8 +609,7 @@ static WORD sh_ldapp(SHELL *psh)
     {
         /* start the EmuCON shell: */
         aes_run_rom_program(coma_start);
-        psh->sh_nextapp = DESKTOP_APP;
-        psh->sh_isgem = TRUE;
+        set_default_desktop(psh);
         return 0;
     }
 #endif

--- a/aes/gemshlib.c
+++ b/aes/gemshlib.c
@@ -522,24 +522,27 @@ static void sh_chgrf(SHELL *psh)
 }
 
 
+static void set_drvdir(char *path)
+{
+    if (path[1] == ':')     /* set default drive (if specified) */
+        dos_sdrv(path[0] - 'A');
+    dos_chdir(path);        /* and default directory */
+}
+
+
 static void sh_chdef(SHELL *psh)
 {
     int n;
 
     switch(psh->sh_nextapp) {
     case NORMAL_APP:
-        if (sh_apdir[1] == ':')     /* set default drive (if specified) */
-            dos_sdrv(sh_apdir[0] - 'A');
-        dos_chdir(sh_apdir);        /* and default directory */
+        set_drvdir(sh_apdir);
         break;
     case CONSOLE_APP:
         break;
     case AUTORUN_APP:
     case DESKTOP_APP:
-        if (psh->sh_cdir[1] == ':')
-            dos_sdrv(psh->sh_cdir[0] - 'A');
-        dos_chdir(psh->sh_cdir);
-
+        set_drvdir(psh->sh_cdir);
         /*
          * if not the default desktop, build a fully-qualified name
          */

--- a/aes/gemshlib.c
+++ b/aes/gemshlib.c
@@ -326,45 +326,7 @@ char *sh_name(char *ppath)
  */
 void sh_envrn(char **ppath, const char *psrch)
 {
-	shellutl_getenv(ad_envrn, psrch, ppath);
-}
-
-
-/*
- *  Search next style routine to pick up each path in the PATH= portion
- *  of the DOS environment.  It returns a pointer to the start of the
- *  following path until there are no more paths to find.
- */
-static char *sh_path(char *src, char *dest, char *pname)
-{
-    char last = 0;
-    char *p;
-
-    if (!src)           /* precautionary */
-        return NULL;
-
-    /* check for end of PATH= env var */
-    if (!*src)
-        return NULL;
-
-    /* copy over path */
-    for (p = src; *p; )
-    {
-        if ((*p == ';') || (*p == ','))
-            break;
-        last = *p;
-        *dest++ = *p++;
-    }
-
-    /* see if extra slash is needed */
-    if ((last != '\\') && (last != ':'))
-        *dest++ = '\\';
-
-    /* append file name */
-    strcpy(dest, pname);
-
-    /* point past terminating separator or nul */
-    return p + 1;
+    shellutl_getenv(ad_envrn, psrch, ppath);
 }
 
 

--- a/aes/gemshlib.c
+++ b/aes/gemshlib.c
@@ -438,9 +438,11 @@ static WORD findfile(char *pspec)
 
     while(1)
     {
-        path = sh_path(path, D.g_work, pname);
-        if (!path)                  /* end of PATH= */
+        path = shellutl_find_next_path_component(path, D.g_work);
+        if (path == NULL)                  /* end of PATH= */
             break;
+
+        strcat(pname,path);
         if (dos_sfirst(D.g_work, FA_RO | FA_HIDDEN | FA_SYSTEM) == 0)   /* found */
         {
             strcpy(pspec, D.g_work);

--- a/aes/gemshlib.c
+++ b/aes/gemshlib.c
@@ -48,6 +48,7 @@
 #include "gemmnlib.h"
 
 #include "string.h"
+#include "shellutl.h"
 
 #include "gemshlib.h"
 #include "../desk/deskstub.h"
@@ -325,25 +326,7 @@ char *sh_name(char *ppath)
  */
 void sh_envrn(char **ppath, const char *psrch)
 {
-    char *p;
-    WORD len;
-
-    len = strlen(psrch);
-    *ppath = NULL;
-
-    /*
-     * scan environment string until double nul
-     */
-    for (p = ad_envrn; *p; )
-    {
-        if (strncmp(p, psrch, len) == 0)
-        {
-            *ppath = p + len;
-            break;
-        }
-        while(*p++) /* skip to end of current env variable */
-            ;
-    }
+	shellutl_getenv(ad_envrn, psrch, ppath);
 }
 
 

--- a/bios/blkdev.c
+++ b/bios/blkdev.c
@@ -476,6 +476,9 @@ static LONG blkdev_rwabs(WORD rw, UBYTE *buf, WORD cnt, WORD recnr, WORD dev, LO
                 return E_CHNG;
             }
         }
+
+        /* In logical mode RW_NOBYTESWAP is not supported. */
+        rw &= ~RW_NOBYTESWAP;
     }
     else {                              /* physical */
         if (unit < 0 || unit >= UNITSNUM || !units[unit].valid)

--- a/bios/disk.h
+++ b/bios/disk.h
@@ -62,6 +62,8 @@
 #define RW_NOMEDIACH        2
 #define RW_NORETRIES        4
 #define RW_NOTRANSLATE      8
+/* EmuTOS extension: Rwabs without byteswap on IDE */
+#define RW_NOBYTESWAP     128
 
 /*
  *  return codes

--- a/bios/screen.c
+++ b/bios/screen.c
@@ -1034,27 +1034,9 @@ WORD getrez(void)
  *  . sets the screen resolution iff 0 <= rez <= 7
  *      if a VIDEL is present and rez==3, then the video mode is
  *      set by a call to vsetmode with 'videlmode' as the argument
- *
- * in addition, EmuTOS implements the following extensions iff
- * logLoc<0 and physLoc<0 and the 0x8000 bit is set in rez (TOS will
- * ignore these since it ignores negative values of 'rez'):
- *  . if the 0x4000 bit is set in rez, the palette registers are
- *    initialised according to 'rez' (bits 2-0) and 'videlmode'
  */
 void setscreen(UBYTE *logLoc, const UBYTE *physLoc, WORD rez, WORD videlmode)
 {
-    /* handle EmuCON extensions */
-    if (((LONG)logLoc < 0) && ((LONG)physLoc < 0) && (rez & 0x8000)) {
-        /* Don't allow any changes when Line A variables were 'hacked'. */
-        if (rez_was_hacked) {
-            return;
-        }
-        if (rez & 0x4000) {
-            initialise_palette_registers(rez&0x0007, videlmode);
-        }
-        return;
-    }
-
 #if CONF_WITH_VIDEL
     /*
      * fixup videl mode if applicable (this is where we could test

--- a/bios/screen.h
+++ b/bios/screen.h
@@ -89,10 +89,7 @@ WORD esetsmear(WORD mode);
 
 #endif /* CONF_WITH_ATARI_VIDEO */
 
-/* misc routines */
-void initialise_palette_registers(WORD rez,WORD mode);
-
-/* determine screen address, monitor type, ... */
+/* set screen address, mode, ... */
 void screen_init_address(void);
 void screen_init_mode(void);
 void set_rez_hacked(void);

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -22,7 +22,7 @@ all: default
 
 VPATH = ../util
 OBJECTS = cmdasm.o cmdmain.o cmdedit.o cmdexec.o cmdint.o cmdparse.o cmdutil.o \
-          version.o doprintf.o
+          version.o doprintf.o shellutl.o
 HEADERS = cmd.h
 
 %.o: %.c $(HEADERS)

--- a/cli/cmd.h
+++ b/cli/cmd.h
@@ -27,6 +27,7 @@
 
 #include "portab.h"
 
+extern char *environment; /* environment string, from cmdasm.S */
 
 /*
  * system calls

--- a/cli/cmd.h
+++ b/cli/cmd.h
@@ -243,7 +243,6 @@ void message(const char *msg);
 void messagenl(const char *msg);
 const char *program_extension(const DTA *dta);
 WORD strequal(const char *s1,const char *s2);
-char *strlower(char *str);
 char *strupper(char *str);
 
 /* cmdasm.S */

--- a/cli/cmd.h
+++ b/cli/cmd.h
@@ -131,6 +131,7 @@ extern LONG jmp_xbios(WORD, ...);
 #define TT_MEDIUM       4
 #define TT_HIGH         6
 #define TT_LOW          7
+#define BLACK           0x0000          /* for Setcolor() */
 
 /*
  *  typedefs

--- a/cli/cmdasm.S
+++ b/cli/cmdasm.S
@@ -18,6 +18,7 @@
         .globl  _coma_start
         .globl  _getwh,_getht
         .globl  _jmp_gemdos,_jmp_bios,_jmp_xbios
+        .globl  _environment
         .extern _cmdmain
 
         .text
@@ -34,6 +35,8 @@ _coma_start:
         move.w  #74,-(sp)
         trap    #1
         lea     12(sp),sp
+
+        move.l  44(a5),_environment
 
         jsr     _cmdmain
 
@@ -97,6 +100,8 @@ _jmp_xbios:
         rts
 
         .bss
+_environment: // Environment string, from the BASEPAGE
+        .ds.l   1
 ret_addr:
         .ds.l   1
 save_a2:

--- a/cli/cmdexec.c
+++ b/cli/cmdexec.c
@@ -11,6 +11,7 @@
  */
 #include "cmd.h"
 #include "string.h"
+#include "shellutl.h"
 
 static UWORD old_stdout;
 
@@ -115,7 +116,8 @@ char temp[MAXPATHLEN];
 const char *p;
 
     for (p = user_path; *p; ) {
-        if (get_path_component(&p,temp) == 0)
+        p = shellutl_find_next_path_component(p,temp);
+        if (p == NULL)
             return -1;
         add_to_path(temp,name);
         if (find_executable(path,temp) == 0)

--- a/cli/cmdmain.c
+++ b/cli/cmdmain.c
@@ -110,7 +110,8 @@ WORD argc, rc;
             largv[0] = "path";
             execute(2,largv,redir_name);
         }
-		shellutl_getenv(environment,"HOME=",&largv[1]);
+#if 0
+        shellutl_getenv(environment,"HOME=",&largv[1]);
         if (largv[1] && largv[1][0]) {
             /* cd ${HOME} */
             largv[0] = "cd";
@@ -124,6 +125,7 @@ WORD argc, rc;
                 execute(1,largv,redir_name);
             }
         }
+#endif
     }
 
     while(1) {

--- a/cli/cmdmain.c
+++ b/cli/cmdmain.c
@@ -110,22 +110,6 @@ WORD argc, rc;
             largv[0] = "path";
             execute(2,largv,redir_name);
         }
-#if 0
-        shellutl_getenv(environment,"HOME=",&largv[1]);
-        if (largv[1] && largv[1][0]) {
-            /* cd ${HOME} */
-            largv[0] = "cd";
-            execute(2,largv,redir_name);
-
-            if (largv[1][1] == ':') {
-                /* Switch to drive */
-                char set_drive[]="x:";
-                set_drive[0] = largv[1][0];
-                largv[0] = set_drive;
-                execute(1,largv,redir_name);
-            }
-        }
-#endif
     }
 
     while(1) {

--- a/cli/cmdmain.c
+++ b/cli/cmdmain.c
@@ -207,6 +207,11 @@ int i;
 PRIVATE void change_res(WORD res)
 {
 #if CONF_ATARI_HARDWARE
+    WORD fgcol, bgcol;
+
+    MAYBE_UNUSED(fgcol);
+    MAYBE_UNUSED(bgcol);
+
     if (res == current_res)
         return;
 
@@ -226,8 +231,27 @@ PRIVATE void change_res(WORD res)
         Setcolor(3,BLACK);
     else if (current_res == ST_MEDIUM)
         Setcolor(3,original_color3);
+    fgcol = 15; /* OS masks color index, so 15 is fine also for mono/medium modes */
+    bgcol = 0;
+
+    /*
+     * handle ST high
+     *
+     * this can only happen with the TT shifter, and in this case ST high
+     * is implemented via the TT 'Duochrome' mode, so we must reverse
+     * foreground & background colours (see comments in bios/screen.c
+     * for the gory details)
+     */
+    if (res == ST_HIGH) {
+        fgcol = 0;
+        bgcol = 15;
+    }
+
     escape('b');    /* ESC b => set foreground colour */
-    conout(15);     /* OS masks color index, so 15 is fine also for mono/medium modes */
+    conout(fgcol);
+    escape('c');    /* ESC c => set background colour */
+    conout(bgcol);
+    clear_screen();
 #endif
     enable_cursor();
     current_res = res;

--- a/cli/cmdmain.c
+++ b/cli/cmdmain.c
@@ -23,6 +23,7 @@
  */
 #include "cmd.h"
 #include "version.h"
+#include "shellutl.h"
 
 /*
  *  global variables
@@ -98,6 +99,32 @@ WORD argc, rc;
 
     if (init_cmdedit() < 0)
         messagenl(_("warning: no history buffers"));
+
+    {
+        /* Setup path from the PATH environment variable
+         * (should be correctly formatted, no TOS quirk) */
+        char *largv[2];
+        shellutl_getenv(environment,"PATH=",&largv[1]);
+        if (largv[1] && largv[1][0]) {
+            /* path ${PATH$} */
+            largv[0] = "path";
+            execute(2,largv,redir_name);
+        }
+		shellutl_getenv(environment,"HOME=",&largv[1]);
+        if (largv[1] && largv[1][0]) {
+            /* cd ${HOME} */
+            largv[0] = "cd";
+            execute(2,largv,redir_name);
+
+            if (largv[1][1] == ':') {
+                /* Switch to drive */
+                char set_drive[]="x:";
+                set_drive[0] = largv[1][0];
+                largv[0] = set_drive;
+                execute(1,largv,redir_name);
+            }
+        }
+    }
 
     while(1) {
         init_screen();      /* init variables for screen size */

--- a/cli/cmdmain.c
+++ b/cli/cmdmain.c
@@ -209,21 +209,14 @@ PRIVATE void change_res(WORD res)
 #if CONF_ATARI_HARDWARE
     WORD fgcol, bgcol;
 
-    MAYBE_UNUSED(fgcol);
-    MAYBE_UNUSED(bgcol);
-
     if (res == current_res)
         return;
 
     Setscreen(-1L,-1L,res,0);
-#ifndef STANDALONE_CONSOLE
-    /* use EmuTOS extension to initialize palette for given resolution */
-    Setscreen(-1L,-1L,0xc000|res,0);
-#else
-    /* mode changed *without* palette change -> set readable text color index */
 
     /*
-     * handle ST medium:
+     * set readable text color index for ST medium
+     *
      *  when switching to ST medium, ensure colour 3 is black
      *  when switching from ST medium, restore original colour
      */
@@ -235,7 +228,7 @@ PRIVATE void change_res(WORD res)
     bgcol = 0;
 
     /*
-     * handle ST high
+     * handle ST high (i.e. TT 'Duochrome')
      *
      * this can only happen with the TT shifter, and in this case ST high
      * is implemented via the TT 'Duochrome' mode, so we must reverse
@@ -251,8 +244,8 @@ PRIVATE void change_res(WORD res)
     conout(fgcol);
     escape('c');    /* ESC c => set background colour */
     conout(bgcol);
+
     clear_screen();
-#endif
     enable_cursor();
     current_res = res;
 #endif

--- a/cli/cmdutil.c
+++ b/cli/cmdutil.c
@@ -112,20 +112,6 @@ const char *p;
 }
 
 /*
- *  convert a string to lowercase
- */
-char *strlower(char *str)
-{
-char *p;
-
-    for (p = str; *p; p++)
-        if ((*p >= 'A') && (*p <= 'Z'))
-            *p |= 0x20;
-
-    return str;
-}
-
-/*
  *  convert a string to uppercase
  */
 char *strupper(char *str)
@@ -219,40 +205,6 @@ unsigned char date_sep;
     return p - s;
 }
 
-/*
- *  copies next path component from buffer &
- *  updates buffer pointer
- *
- *  returns:
- *      1   arg is normal
- *      0   no more args
- */
-WORD get_path_component(const char **pp,char *dest)
-{
-const char *p;
-char *q = dest;
-
-    /*
-     *  look for start of next component
-     */
-    for (p = *pp; *p; p++)
-        if (*p != ';')
-            break;
-    if (!*p) {          /* end of buffer */
-        *pp = p;
-        return 0;
-    }
-
-    while(*p) {
-        if (*p == ';')
-            break;
-        *q++ = *p++;
-    }
-    *q = '\0';
-
-    *pp = p;
-    return 1;
-}
 
 WORD has_wildcard(const char *name)
 {

--- a/cli/cmdutil.c
+++ b/cli/cmdutil.c
@@ -245,23 +245,8 @@ const char *p;
  */
 WORD strequal(const char *s1,const char *s2)
 {
-const char *p, *q;
-char c1, c2;
+    return !strncasecmp(s1,s2,-1L);
 
-    for (p = s1, q = s2; *p; ) {
-        c1 = *p++;
-        if ((c1 >= 'A') && (c1 <= 'Z'))
-            c1 |= 0x20;
-        c2 = *q++;
-        if ((c2 >= 'A') && (c2 <= 'Z'))
-            c2 |= 0x20;
-        if (c1 != c2)
-            return 0;
-    }
-    if (*q)
-        return 0;
-
-    return 1;
 }
 
 PRIVATE LONG getjar(void)

--- a/cli/cmdutil.c
+++ b/cli/cmdutil.c
@@ -390,6 +390,22 @@ int toupper(int c)
         return(c);
 }
 
+int strncmp(const char *a, const char *b, size_t n)
+{
+    unsigned char s1, s2;
+
+    while(n-- > 0) {
+        s1 = (unsigned char)*a++;
+        s2 = (unsigned char)*b++;
+        if (s1 != s2)
+            return s1 - s2;
+        if (s1 == '\0')
+            break;
+    }
+
+    return 0;
+}
+
 int strncasecmp(const char *a, const char *b, size_t n)
 {
     unsigned char s1, s2;

--- a/desk/aesbind.h
+++ b/desk/aesbind.h
@@ -177,7 +177,9 @@ WORD shel_put(const void *pdata, WORD len);
 WORD shel_find(char *ppath);
 WORD shel_envrn(char *ppath, const char *psrch);
 WORD shel_rdef(char *lpcmd, char *lpdir);
-WORD shel_wdef(char *lpcmd, char *lpdir);
 */
+#if WITH_CLI
+WORD shel_wdef(char *lpcmd, char *lpdir);
+#endif
 
 #endif  /* _AESBIND_H */

--- a/desk/deskmain.c
+++ b/desk/deskmain.c
@@ -729,14 +729,13 @@ static WORD do_filemenu(WORD item)
         {
             /*
              * set default directory according to path in topped window
-             *
-             * note that it is safe to trim the trailing wildcard spec
-             * in the PNODE because the latter will be recreated when
-             * EmuDesk starts up after EmuCON exits.
              */
-            char *p = filename_start(pw->w_pnode.p_spec);
+            char *p;
+
+            strcpy(G.g_work, pw->w_pnode.p_spec);
+            p = filename_start(G.g_work);
             *p = '\0';
-            shel_wdef("", pw->w_pnode.p_spec);
+            shel_wdef("", G.g_work);
         }
         break;
 #endif

--- a/desk/deskmain.c
+++ b/desk/deskmain.c
@@ -725,6 +725,19 @@ static WORD do_filemenu(WORD item)
     case CLIITEM:                         /* Start EmuCON */
         G.g_work[1] = '\0';
         done = pro_run(FALSE, DEF_CONSOLE, G.g_work, -1, -1);
+        if (done && pw)
+        {
+            /*
+             * set default directory according to path in topped window
+             *
+             * note that it is safe to trim the trailing wildcard spec
+             * in the PNODE because the latter will be recreated when
+             * EmuDesk starts up after EmuCON exits.
+             */
+            char *p = filename_start(pw->w_pnode.p_spec);
+            *p = '\0';
+            shel_wdef("", pw->w_pnode.p_spec);
+        }
         break;
 #endif
 

--- a/desk/gembind.c
+++ b/desk/gembind.c
@@ -976,11 +976,11 @@ WORD shel_rdef(char *lpcmd, char *lpdir)
 }
 */
 
-/* unused
+#if WITH_CLI
 WORD shel_wdef(char *lpcmd, char *lpdir)
 {
     SH_LPCMD = (LONG)lpcmd;
     SH_LPDIR = (LONG)lpdir;
     return gem_if(AES_CTRL_CODE(SHEL_WDEF, 0, 1, 2));
 }
-*/
+#endif

--- a/include/biosext.h
+++ b/include/biosext.h
@@ -77,6 +77,7 @@ WORD get_palette(void);
 void get_pixel_size(WORD *width,WORD *height);
 int rez_changeable(void);
 WORD check_moderez(WORD moderez);
+void initialise_palette_registers(WORD rez,WORD mode);
 
 /* RAM-copies of the ROM-fontheaders. See bios/fntxxx.c */
 extern struct font_head fon6x6;

--- a/include/shellutl.h
+++ b/include/shellutl.h
@@ -12,12 +12,13 @@
  * option any later version.  See doc/license.txt for details.
  */
 
+#ifndef _SHELLUTL_H
+#define _SHELLUTL_H
+
 #include <portab.h>
 
-/*
- *  Search for a particular string in the DOS environment and return a
- *  value in the pointer pointed to by the first argument.  If the string
- *  is found, the value is a pointer to the first character after the
- *  string; otherwise it is a NULL pointer.
- */
 void shellutl_getenv(const char *environment, const char *varname, char **out_value);
+char *shellutl_find_next_path_component(const char *paths, char *dest);
+WORD shellutl_get_drive_number(char drive_letter);
+
+#endif

--- a/include/shellutl.h
+++ b/include/shellutl.h
@@ -1,0 +1,26 @@
+/*
+ * Shell utility functions.
+ * These are factored functions that may be used by both the
+ * AES, Desktop and embedded CLI (EmuCON)
+ *
+ * Copyright (C) 2013-2022 The EmuTOS development team
+ *
+ * Authors:
+ *  RFB    Roger Burrows
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include <portab.h>
+#include <config.h>
+#include "string.h"
+
+
+/*
+ *  Search for a particular string in the DOS environment and return a
+ *  value in the pointer pointed to by the first argument.  If the string
+ *  is found, the value is a pointer to the first character after the
+ *  string; otherwise it is a NULL pointer.
+ */
+void shellutl_getenv(const char *environment, const char *varname, char **out_value);

--- a/include/shellutl.h
+++ b/include/shellutl.h
@@ -6,7 +6,7 @@
  * Copyright (C) 2013-2022 The EmuTOS development team
  *
  * Authors:
- *  RFB    Roger Burrows
+ *  VB    Vincent Barrilliot
  *
  * This file is distributed under the GPL, version 2 or at your
  * option any later version.  See doc/license.txt for details.
@@ -17,8 +17,8 @@
 
 #include <portab.h>
 
-void shellutl_getenv(const char *environment, const char *varname, char **out_value);
+void  shellutl_getenv(const char *environment, const char *varname, char **out_value);
 char *shellutl_find_next_path_component(const char *paths, char *dest);
-WORD shellutl_get_drive_number(char drive_letter);
+WORD  shellutl_get_drive_number(char drive_letter);
 
 #endif

--- a/include/shellutl.h
+++ b/include/shellutl.h
@@ -13,9 +13,6 @@
  */
 
 #include <portab.h>
-#include <config.h>
-#include "string.h"
-
 
 /*
  *  Search for a particular string in the DOS environment and return a

--- a/util/shellutl.c
+++ b/util/shellutl.c
@@ -13,6 +13,8 @@
  */
 
 #include "shellutl.h"
+#include <config.h>
+#include "string.h"
 
 /*
  *  Search for a particular string in the DOS environment and return a

--- a/util/shellutl.c
+++ b/util/shellutl.c
@@ -1,19 +1,20 @@
 /*
  * Shell utility functions.
  * These are factored functions that may be used by both the
- * AES, Desktop and embedded CLI (EmuCON)
+ * AES, Desktop and embedded CLI (EmuCON2)
  *
  * Copyright (C) 2013-2022 The EmuTOS development team
  *
  * Authors:
- *  RFB    Roger Burrows
+ *  VB     Vincent Barrilliot
  *
  * This file is distributed under the GPL, version 2 or at your
  * option any later version.  See doc/license.txt for details.
  */
 
-#include "shellutl.h"
 #include <config.h>
+
+#include "shellutl.h"
 #include "string.h"
 
 /*

--- a/util/shellutl.c
+++ b/util/shellutl.c
@@ -1,0 +1,44 @@
+/*
+ * Shell utility functions.
+ * These are factored functions that may be used by both the
+ * AES, Desktop and embedded CLI (EmuCON)
+ *
+ * Copyright (C) 2013-2022 The EmuTOS development team
+ *
+ * Authors:
+ *  RFB    Roger Burrows
+ *
+ * This file is distributed under the GPL, version 2 or at your
+ * option any later version.  See doc/license.txt for details.
+ */
+
+#include "shellutl.h"
+
+/*
+ *  Search for a particular string in the DOS environment and return a
+ *  value in the pointer pointed to by the first argument.  If the string
+ *  is found, the value is a pointer to the first character after the
+ *  string; otherwise it is a NULL pointer.
+ */
+void shellutl_getenv(const char *environment, const char *varname, char **out_value)
+{
+    char *p;
+    WORD len;
+
+    len = strlen(varname);
+    *out_value = NULL;
+
+    /*
+     * scan environment string until double nul
+     */
+    for (p = (char*)environment; *p; )
+    {
+        if (strncmp(p, varname, len) == 0)
+        {
+            *out_value = p + len;
+            break;
+        }
+        while(*p++) /* skip to end of current env variable */
+            ;
+    }
+}

--- a/util/shellutl.c
+++ b/util/shellutl.c
@@ -44,3 +44,48 @@ void shellutl_getenv(const char *environment, const char *varname, char **out_va
             ;
     }
 }
+
+
+/*
+ *  "Search next"-style routine to pick up each path component in a
+ *  list of paths separated by ";" or ",".
+ *  Returns a pointer to the start of the following component path
+ *  there are no more paths to find.
+ */
+char *shellutl_find_next_path_component(const char *paths, char *dest)
+{
+    char last = 0;
+    char *p;
+
+    if (!paths)           /* precautionary */
+        return NULL;
+
+    /* check for end of PATH= env var */
+    if (!*paths)
+        return NULL;
+
+    /* copy over path */
+    for (p = (char*)paths; *p; )
+    {
+        if ((*p == ';') || (*p == ','))
+            break;
+        last = *p;
+        *dest++ = *p++;
+    }
+
+    /* see if extra slash is needed */
+    if ((last != '\\') && (last != ':'))
+        *dest++ = '\\';
+
+	*dest = '\0';
+
+    /* point past terminating separator or nul */
+    return *p ? p + 1 : p;
+}
+
+/*
+ *  Return a drive number from a drive letter (lower or upper case)
+ */
+WORD shellutl_get_drive_number(char drive_letter) {
+	return (drive_letter | 0x20) - 'a';
+}

--- a/util/string.c
+++ b/util/string.c
@@ -28,8 +28,8 @@ char *strcpy(char *dest, const char *src)
 {
     char *tmp = dest;
 
-    while( (*tmp++ = *src++) )
-        ;
+    while( (*tmp++ = *src++) );
+	*dest = '\0';
     return dest;
 }
 #endif


### PR DESCRIPTION
Change EmuCON so it gets the PATH= from its environment if present.
Factor the environment management between the shell lib of the AES and EmuCON to keep the extra memory consumption small for this change (20 bytes).
