### PR TITLE
Force blitter use if present, to reduce ROM size

### DIFF
--- a/aes/geminit.c
+++ b/aes/geminit.c
@@ -440,10 +440,14 @@ static BOOL process_inf2(BOOL *isauto)
             pcurr = scan_2(pcurr, &env);
             ev_dclick(env & 0x07, TRUE);
             pcurr = scan_2(pcurr, &env);    /* get desired blitter state */
-#if CONF_WITH_BLITTER
+#if MPS_BLITTER_ALWAYS_ON
+	    Blitmode(1);
+#else
+  #if CONF_WITH_BLITTER
             if (has_blitter)
                 Blitmode((env&0x80)?1:0);
-#endif
+  #endif
+#endif // MPS_BLITTER_ALWAYS_ON
 #if CONF_WITH_CACHE_CONTROL
             pcurr = scan_2(pcurr, &env);    /* skip over video bytes if present */
             pcurr = scan_2(pcurr, &env);

--- a/bios/bios.c
+++ b/bios/bios.c
@@ -280,7 +280,8 @@ static void bios_init(void)
     KDEBUG(("font_init()\n"));
     font_init();        /* initialize font ring (requires cookie_akp) */
 
-#if CONF_WITH_BLITTER
+#if !MPS_STF && !MPS_STE
+  #if CONF_WITH_BLITTER
     /*
      * If a PAK 68/3 is installed, the blitter cannot access the PAK ROMs.
      * So we must mark the blitter as not installed (this is what the
@@ -290,6 +291,7 @@ static void bios_init(void)
     if ((mcpu == 30)
      && ((cookie_mch == MCH_ST) || (cookie_mch == MCH_STE) || (cookie_mch == MCH_MSTE)))
         has_blitter = 0;
+  #endif
 #endif
 
     /*

--- a/bios/machine.c
+++ b/bios/machine.c
@@ -289,6 +289,7 @@ static void detect_magnum(void)
 
 #endif /* CONF_WITH_MAGNUM */
 
+#if !MPS_BLITTER_ALWAYS_ON
 #if CONF_WITH_BLITTER
 
 /* blitter */
@@ -317,7 +318,7 @@ static void detect_blitter(void)
 }
 
 #endif /* CONF_WITH_BLITTER */
-
+#endif // MPS_BLITTER_ALWAYS_ON
 
 #if CONF_WITH_DIP_SWITCHES
 
@@ -570,7 +571,7 @@ void machine_detect(void)
 #if CONF_WITH_DIP_SWITCHES
     detect_dip_switches();
 #endif
-#if CONF_WITH_BLITTER
+#if CONF_WITH_BLITTER && !MPS_BLITTER_ALWAYS_ON
     detect_blitter();
 #endif
 #if CONF_WITH_IDE

--- a/bios/xbios.c
+++ b/bios/xbios.c
@@ -871,6 +871,9 @@ static WORD xbios_2e(WORD op, WORD start, WORD count, UBYTE *buffer)
  */
 static WORD blitmode(WORD mode)
 {
+#if MPS_BLITTER_ALWAYS_ON
+    return  1 << 1;
+#else
 #if CONF_WITH_BLITTER
     WORD status = 0x0000;
 
@@ -886,6 +889,7 @@ static WORD blitmode(WORD mode)
 #else
     return 0x0000;
 #endif
+#endif // MPS_BLITTER_ALWAYS_ON
 }
 
 #if DBG_XBIOS

--- a/desk/deskbind.h
+++ b/desk/deskbind.h
@@ -175,7 +175,9 @@ typedef struct
 /*GLOBAL*/ char         g_cdclkpref;            /* double click speed           */
 /*GLOBAL*/ char         g_ctimeform;            /* time format                  */
 /*GLOBAL*/ char         g_cdateform;            /* date format                  */
+#if !MPS_BLITTER_ALWAYS_ON
 /*GLOBAL*/ char         g_blitter;              /* blitter enabled (boolean)    */
+#endif
 /*GLOBAL*/ char         g_cache;                /* cache enabled (boolean)      */
 /*GLOBAL*/ char         g_appdir;               /* default is app dir (boolean) */
 /*GLOBAL*/ char         g_fullpath;             /* full path for arg (boolean)  */

--- a/desk/deskmain.c
+++ b/desk/deskmain.c
@@ -342,7 +342,9 @@ static const UBYTE dura[EGG_NOTES] =
 static char separator[MAXLEN_SEPARATOR+1];
 
 static int can_change_resolution;
+#if !MPS_BLITTER_ALWAYS_ON
 static int blitter_is_present;
+#endif
 #if CONF_WITH_CACHE_CONTROL
 static int cache_is_present;
 #endif
@@ -387,7 +389,9 @@ static void play_sound(UWORD frequency, UWORD duration)
 static void detect_features(void)
 {
     can_change_resolution = rez_changeable();
+#if !MPS_BLITTER_ALWAYS_ON
     blitter_is_present = Blitmode(-1) & 0x0002;
+#endif
 #if CONF_WITH_CACHE_CONTROL
     cache_is_present = cache_exists();
 #endif
@@ -565,14 +569,19 @@ static void men_update(void)
 
     menu_ienable(tree, RESITEM, can_change_resolution);
 
-#if CONF_WITH_BLITTER
+#if MPS_BLITTER_ALWAYS_ON
+    menu_ienable(tree, BLITITEM, FALSE); // Cannot disable blitter
+    menu_icheck(tree, BLITITEM, TRUE);
+#else
+  #if CONF_WITH_BLITTER
     if (blitter_is_present)
     {
-        menu_ienable(tree, BLITITEM, TRUE);
-        menu_icheck(tree, BLITITEM, G.g_blitter);
+	menu_ienable(tree, BLITITEM, TRUE);
+	menu_icheck(tree, BLITITEM, G.g_blitter);
     }
     else
         menu_ienable(tree, BLITITEM, FALSE);
+  #endif
 #endif
 
 #if CONF_WITH_CACHE_CONTROL
@@ -896,7 +905,7 @@ static WORD do_optnmenu(WORD item)
         }
         break;
 #endif
-#if CONF_WITH_BLITTER
+#if CONF_WITH_BLITTER && !MPS_BLITTER_ALWAYS_ON
     case BLITITEM:
         G.g_blitter = !G.g_blitter;
         menu_icheck(desk_rs_trees[ADMENU], BLITITEM, G.g_blitter);  /* flip blit mode */
@@ -1350,7 +1359,9 @@ static void cnx_put(void)
     cnxsave->cs_confovwr = G.g_covwrpref;
     cnxsave->cs_timefmt = G.g_ctimeform;
     cnxsave->cs_datefmt = G.g_cdateform;
-    cnxsave->cs_blitter = G.g_blitter;
+#if !MPS_BLITTER_ALWAYS_ON
+    cnxsave->cs_blitter = TRUE;
+#endif
 #if CONF_WITH_CACHE_CONTROL
     cnxsave->cs_cache = G.g_cache;
 #endif
@@ -1411,7 +1422,9 @@ static void cnx_get(void)
     G.g_cdclkpref = cnxsave->cs_dblclick;
     G.g_ctimeform = cnxsave->cs_timefmt;
     G.g_cdateform = cnxsave->cs_datefmt;
+#if !MPS_BLITTER_ALWAYS_ON
     G.g_blitter   = cnxsave->cs_blitter;
+#endif
 #if CONF_WITH_CACHE_CONTROL
     G.g_cache     = cnxsave->cs_cache;
     menu_icheck(desk_rs_trees[ADMENU], CACHITEM, G.g_cache);
@@ -1993,7 +2006,7 @@ BOOL deskmain(void)
     cnx_get();
     wind_update(END_UPDATE);
 
-#if CONF_WITH_BLITTER
+#if CONF_WITH_BLITTER && !MPS_BLITTER_ALWAYS_ON
     /*
      * we now have the desired blitter state from EMUDESK.INF, so we can
      * call Blitmode() here.  note that we call it here, even if we've

--- a/readme-mps.txt
+++ b/readme-mps.txt
@@ -12,3 +12,10 @@ Changelog:
 2020-Mar-10 VB:
 	* Support ACCPATH environment variable in the AES, indicating the folder where to search
 	  for accessories. Must not include trailing backslash.
+	  
+2020-Mar-13 VB:
+	* Reduce size by doing the following:
+	  * On STf (MPS_STF=1), don't include blitter code.
+	  * On STe (MPS_STE=1), always use blitter and don't include software blitter emulation.
+	  This is controlled by the MPS_BLITTER_ALWAYS_ON compile switch.
+	  

--- a/vdi/vdi_blit.S
+++ b/vdi/vdi_blit.S
@@ -7,7 +7,8 @@
  * This file is distributed under the GPL, version 2 or at your
  * option any later version.  See doc/license.txt for details.
  */
-
+#include "../localconf.h"
+#if ASM_BLIT_IS_AVAILABLE
 #include "asmdefs.h"
 
         .globl  _fast_bit_blt
@@ -1404,3 +1405,4 @@ sc_mp_enter:
 sc_plane:
         dbra    d4,sc_mp_enter
         rts
+#endif

--- a/vdi/vdi_raster.c
+++ b/vdi/vdi_raster.c
@@ -324,7 +324,7 @@ hwblit_raster(BLITVARS *blt)
 #endif
 
 
-#if !ASM_BLIT_IS_AVAILABLE
+#if !ASM_BLIT_IS_AVAILABLE && !MPS_BLITTER_ALWAYS_ON
 /*
  * the following is a modified version of a blitter emulator, with the HOP
  * processing removed since it is always called with a HOP value of 2 (source)
@@ -660,20 +660,24 @@ static void bit_blt(struct blit_frame *blit_info)
          * (b) we are on 68K (ASM_BLIT_IS_AVAILABLE is 1): the
          *     hardware blitter must be enabled to get here.
          */
-#if !ASM_BLIT_IS_AVAILABLE
-#if CONF_WITH_BLITTER
+#if MPS_BLITTER_ALWAYS_ON
+	hwblit_raster(blt);
+#else
+  #if !ASM_BLIT_IS_AVAILABLE
+    #if CONF_WITH_BLITTER
         if (blitter_is_enabled)
         {
             hwblit_raster(blt);
         }
         else
-#endif
+    #endif
         {
             do_blit(blt);
         }
-#else
+    #else
         hwblit_raster(blt);
-#endif
+    #endif
+#endif // MPS_BLITTER_ALWAYS_ON
 
         s_addr += blit_info->s_nxpl;          /* a0-> start of next src plane   */
         d_addr += blit_info->d_nxpl;          /* a1-> start of next dst plane   */
@@ -970,20 +974,24 @@ cpy_raster(struct raster_t *raster, struct blit_frame *info)
      * (a) the blitter isn't configured, or
      * (b) it's configured but not available.
      */
-#if ASM_BLIT_IS_AVAILABLE
-#if CONF_WITH_BLITTER
+#if MPS_BLITTER_ALWAYS_ON
+	bit_blt(info);
+#else
+  #if ASM_BLIT_IS_AVAILABLE
+    #if CONF_WITH_BLITTER
     if (blitter_is_enabled)
     {
         bit_blt(info);
     }
     else
-#endif
+    #endif
     {
         fast_bit_blt(info);
     }
-#else
+  #else
     bit_blt(info);
-#endif
+  #endif
+#endif // MPS_BLITTER_ALWAYS_ON
 }
 
 /*
@@ -1059,18 +1067,22 @@ void linea_blit(struct blit_frame *info)
      * (a) the blitter isn't configured, or
      * (b) it's configured but not available.
      */
-#if ASM_BLIT_IS_AVAILABLE
-#if CONF_WITH_BLITTER
+#if MPS_BLITTER_ALWAYS_ON
+    bit_blt(info);
+#else
+  #if ASM_BLIT_IS_AVAILABLE
+    #if CONF_WITH_BLITTER
     if (blitter_is_enabled)
     {
         bit_blt(info);
     }
     else
-#endif
+    #endif
     {
         fast_bit_blt(info);
     }
-#else
+  #else
     bit_blt(info);
-#endif
+  #endif
+#endif // MPS_BLITTER_ALWAYS_ON
 }


### PR DESCRIPTION
	  * On STf (MPS_STF=1), don't include blitter code.
	  * On STe (MPS_STE=1), always use blitter and don't include software blitter emulation.
	  This is controlled by the MPS_BLITTER_ALWAYS_ON compile switch.