### PR TITLE
Add MPS_LINES_LUT to use LUT table (costs 800 bytes) instead of muls …

### DIFF
--- a/localconf.h
+++ b/localconf.h
@@ -1,0 +1,41 @@
+#define NUM_VDI_HANDLES 32
+#define CONF_WITH_TTRAM 0
+#define CONF_WITH_MONSTER 0
+#define CONF_WITH_MAGNUM 0
+#define CONF_WITH_VME 0
+#define CONF_WITH_NOVA 0
+#define INITINFO_DURATION 2
+#define CONF_WITH_COLOUR_ICONS 0
+#define CONF_WITH_EXTENDED_MOUSE 0
+#define CONF_WITH_LOADABLE_CURSORS 0
+#define CONF_WITH_CACHE_CONTROL 0
+#define CONF_WITH_EASTER_EGG 0
+#define CONF_WITH_PRINTER_ICON 0
+#define CONF_WITH_VDI_VERTLINE 1
+
+
+/* If blitter is available, always use it and remove software drawing routines. */
+/* #define MPS_BLITTER_ALWAYS_ON 1 */
+
+/* Use lookup table for line offsets rather than multiply in vdi_misc */
+/* #define MPS_LINES_LUT 1 */
+#define MPS_LINES_LUT 1
+
+/* These are mutually exclusive */
+#define MPS_STF 1
+#define MPS_STE 0
+
+#if MPS_STF
+  /* STf have no blitter so remove related code.
+   * Mega ST are a different beast which is not supported here (rare enough). */
+  #define CONF_WITH_BLITTER 0
+  #define MPS_BLITTER_ALWAYS_ON 0
+  #define ASM_BLIT_IS_AVAILABLE 1
+#endif
+
+#if MPS_STE
+  /* As blitter is available, always use it and don't include software drawing/blitting routines */
+  #define CONF_WITH_BLITTER 1
+  #define ASM_BLIT_IS_AVAILABLE 0
+  #define MPS_BLITTER_ALWAYS_ON 1
+#endif

--- a/vdi/vdi_control.c
+++ b/vdi/vdi_control.c
@@ -171,7 +171,18 @@ Vwk * get_vwk_by_handle(WORD handle)
     return vwk_ptr[handle];
 }
 
+#if MPS_LINES_LUT
+UWORD lineslut[400];
+void lineslut_setup(void);
+void lineslut_setup(void) {
+    UWORD i, offset;
 
+    for (i = offset = 0; i<V_REZ_VT ; i++) {
+        lineslut[i] = offset;
+	offset += BYTES_LIN;
+    }
+}
+#endif
 
 /*
  * update resolution-dependent VDI/lineA variables
@@ -181,6 +192,10 @@ Vwk * get_vwk_by_handle(WORD handle)
 void update_rez_dependent(void)
 {
     BYTES_LIN = v_lin_wr = V_REZ_HZ / 8 * v_planes;
+
+#if MPS_LINES_LUT
+    lineslut_setup();
+#endif
 
 #if EXTENDED_PALETTE
     mcs_ptr = (v_planes <= 4) ? &mouse_cursor_save : &ext_mouse_cursor_save;


### PR DESCRIPTION
…for calculating line offsets. Improves drawing performance by 1.2% according to gembench.
Only supports 400 lines max.